### PR TITLE
Update karma-jasmine-html-reporter and jasmine-core to compatible dependencies.

### DIFF
--- a/angular-app/package-lock.json
+++ b/angular-app/package-lock.json
@@ -29,12 +29,12 @@
         "@angular/compiler-cli": "~12.0.3",
         "@types/jasmine": "~3.6.0",
         "@types/node": "^12.11.1",
-        "jasmine-core": "~3.7.0",
+        "jasmine-core": "~3.8.0",
         "karma": "~6.3.0",
         "karma-chrome-launcher": "~3.1.0",
         "karma-coverage": "~2.0.3",
         "karma-jasmine": "~4.0.0",
-        "karma-jasmine-html-reporter": "^1.5.0",
+        "karma-jasmine-html-reporter": "^1.7.0",
         "typescript": "~4.2.3"
       }
     },
@@ -8280,9 +8280,9 @@
       }
     },
     "node_modules/jasmine-core": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.7.1.tgz",
-      "integrity": "sha512-DH3oYDS/AUvvr22+xUBW62m1Xoy7tUlY1tsxKEJvl5JeJ7q8zd1K5bUwiOxdH+erj6l2vAMM3hV25Xs9/WrmuQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.8.0.tgz",
+      "integrity": "sha512-zl0nZWDrmbCiKns0NcjkFGYkVTGCPUgoHypTaj+G2AzaWus7QGoXARSlYsSle2VRpSdfJmM+hzmFKzQNhF2kHg==",
       "dev": true
     },
     "node_modules/jest-worker": {
@@ -22567,9 +22567,9 @@
       }
     },
     "jasmine-core": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.7.1.tgz",
-      "integrity": "sha512-DH3oYDS/AUvvr22+xUBW62m1Xoy7tUlY1tsxKEJvl5JeJ7q8zd1K5bUwiOxdH+erj6l2vAMM3hV25Xs9/WrmuQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.8.0.tgz",
+      "integrity": "sha512-zl0nZWDrmbCiKns0NcjkFGYkVTGCPUgoHypTaj+G2AzaWus7QGoXARSlYsSle2VRpSdfJmM+hzmFKzQNhF2kHg==",
       "dev": true
     },
     "jest-worker": {

--- a/angular-app/package.json
+++ b/angular-app/package.json
@@ -33,12 +33,12 @@
     "@angular/compiler-cli": "~12.0.3",
     "@types/jasmine": "~3.6.0",
     "@types/node": "^12.11.1",
-    "jasmine-core": "~3.7.0",
+    "jasmine-core": "~3.8.0",
     "karma": "~6.3.0",
     "karma-chrome-launcher": "~3.1.0",
     "karma-coverage": "~2.0.3",
     "karma-jasmine": "~4.0.0",
-    "karma-jasmine-html-reporter": "^1.5.0",
+    "karma-jasmine-html-reporter": "^1.7.0",
     "typescript": "~4.2.3"
   }
 }


### PR DESCRIPTION
npm was not able to resolve jasmine-core and karma-jasmine-html-reporter dependencies due to incompatible versions upon running npm install in angular-app.